### PR TITLE
Check if intent is null in onActivityResult

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -381,6 +381,9 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (intent == null) {
+            return false;
+        }        
         if (pendingOperation == null) {
             return false;
         }


### PR DESCRIPTION
This seems to crash apps when intent is null.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])